### PR TITLE
add browser field to package.json for npmcdn

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "name": "aframe-video-controls",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Video Controls for video assets",
   "main": "index.js",
+  "browser": "dist/aframe-video-controls.min.js",
   "scripts": {
     "build": "browserify examples/main.js -o examples/build.js",
     "dev": "budo examples/main.js:build.js --dir examples --port 8000 --live --open",


### PR DESCRIPTION
Planning on featuring this component in one of our starter kit. Would like the browser field so I can do `npmcdn.com/aframe-video-controls@0.2.1` without having to specify file path.
